### PR TITLE
When given a --list option, don't run the check

### DIFF
--- a/lib/ci-syntax-tool/checker.rb
+++ b/lib/ci-syntax-tool/checker.rb
@@ -14,7 +14,10 @@ module CI
         end
 
         def run
-
+          unless cmd_line.runnable?
+            return cmd_line.non_runnable_exit_status
+          end
+          
           formats = []
           cmd_line.options[:formats].each_with_index do |fmt_name, idx|
             formats << FormatFactory.create(fmt_name, cmd_line.options[:outputs][idx])


### PR DESCRIPTION
Also aborts any other case in which the check is unrunnable.
